### PR TITLE
Add global API exception middleware, XML docs, Swagger improvements and controller response annotations

### DIFF
--- a/ETrocas.API.Internal/Controllers/v1/CadastrarUsuarioController.cs
+++ b/ETrocas.API.Internal/Controllers/v1/CadastrarUsuarioController.cs
@@ -1,65 +1,56 @@
 ﻿using Asp.Versioning;
 using ETrocas.Application.Interfaces;
 using ETrocas.Application.Requests;
+using ETrocas.Application.Responses;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ETrocas.API.Internal.Controllers.v1
 {
+    /// <summary>
+    /// Endpoints para cadastro e autenticação de usuários.
+    /// </summary>
     [ApiController]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion("1.0")]
     [Produces("application/json")]
-
     public class CadastrarUsuarioController : Controller
     {
-        //injeção de dependencia do usuarioService responsável pela lógica de negócios de registro e login de usuários.
         private readonly IUsuarioService _usuarioService;
-        //injeção de dependencia do usuarioService.
+
         public CadastrarUsuarioController(IUsuarioService usuarioService) => _usuarioService = usuarioService;
 
-        //rota (registrar) e metodo http (Post)
+        /// <summary>
+        /// Registra um novo usuário.
+        /// </summary>
+        /// <param name="request">Dados necessários para cadastro.</param>
+        /// <returns>Dados do usuário cadastrado.</returns>
+        /// <response code="200">Usuário cadastrado com sucesso.</response>
+        /// <response code="400">Dados inválidos para cadastro.</response>
         [HttpPost("registrar")]
-        //metodo assincrono Cadastrar que retorna IAction result que permite retornar varios tipos de respostas http, como o OK/BadRequest/NotFound.
+        [ProducesResponseType(typeof(RegistrarUsuarioResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Cadastrar([FromBody] RegistrarUsuarioRequest request)
         {
-            // crio a variavel response, ela acessa a interface IUsuarioService, que contem o contrato de RegistrarUsuarioAsync
-            // nele tem a implementação do serviço que pega os dados, salva no banco com o repository e retorna o response e assim que o
-            // usuario fizer isso no request passado no Body desse metodo, ele vai salvar com as informações do usuario e retornar o response.
-            //conforme definido na classe response.
-            //essa linha é equivalente a RegistrarUsuarioResponse response = await _usuarioService.RegistrarUsuarioAsync(request); 
-            try
-            {
-                var response = await _usuarioService.RegistrarUsuarioAsync(request);
-                return Ok(response);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            var response = await _usuarioService.RegistrarUsuarioAsync(request);
+            return Ok(response);
         }
 
-        //Rota(login) e metodo http (Post)
+        /// <summary>
+        /// Realiza autenticação de usuário e retorna token JWT.
+        /// </summary>
+        /// <param name="loginRequest">Credenciais de acesso do usuário.</param>
+        /// <returns>Token e informações básicas do usuário autenticado.</returns>
+        /// <response code="200">Login efetuado com sucesso.</response>
+        /// <response code="400">Dados de login inválidos.</response>
+        /// <response code="401">Credenciais incorretas.</response>
         [HttpPost("login")]
-
-        //metodo async que usa IActionResult para retornar resposta http tipo OK,BadRequest,NotFound.
+        [ProducesResponseType(typeof(LoginUsuarioResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> Login([FromBody] LoginUsuarioRequest loginRequest)
         {
-            //cria a variavel response, que contem a logica do login no service quando recebe,
-            //o loginRequest passado pelo usuario e retorna OK e resposta.
-            //aqui é o mesmo que usar LoginUsuarioResponse response = await _usuarioService.LoginUsuarioAsync(loginRequest); mas é mais facil usar a variavel
-            try
-            {
-                var response = await _usuarioService.LoginUsuarioAsync(loginRequest);
-                return Ok(response);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                return Unauthorized(ex.Message);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            var response = await _usuarioService.LoginUsuarioAsync(loginRequest);
+            return Ok(response);
         }
     }
 }

--- a/ETrocas.API.Internal/Controllers/v1/ProdutosController.cs
+++ b/ETrocas.API.Internal/Controllers/v1/ProdutosController.cs
@@ -1,30 +1,42 @@
 ﻿using Asp.Versioning;
 using ETrocas.Application.Interfaces;
 using ETrocas.Application.Requests;
+using ETrocas.Application.Responses;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 
 namespace ETrocas.API.Internal.Controllers.v1
 {
-    //atributo [ApiController]
+    /// <summary>
+    /// Endpoints para operações de produtos.
+    /// </summary>
     [ApiController]
-    //rota
     [Route("api/v{version:apiVersion}/[controller]")]
-    //controlador herda de Controller
     [ApiVersion("1.0")]
     [Produces("application/json")]
     public class ProdutosController : Controller
     {
-        //injetar o service na controller pois ele que tem a regra de negocio.
         private readonly IProdutoService _produtoService;
+
         public ProdutosController(IProdutoService produtoService)
         {
             _produtoService = produtoService;
         }
 
+        /// <summary>
+        /// Cadastra um novo produto para o usuário autenticado.
+        /// </summary>
+        /// <param name="cadastrarProdutoRequest">Dados do produto a ser cadastrado.</param>
+        /// <returns>Produto cadastrado.</returns>
+        /// <response code="200">Produto cadastrado com sucesso.</response>
+        /// <response code="400">Dados inválidos para cadastro.</response>
+        /// <response code="401">Usuário não autenticado.</response>
         [Authorize]
         [HttpPost("CadastrarProduto")]
+        [ProducesResponseType(typeof(CadastrarProdutoResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> CadastrarProduto([FromBody] CadastrarProdutoRequest cadastrarProdutoRequest)
         {
             var usuarioId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -32,71 +44,80 @@ namespace ETrocas.API.Internal.Controllers.v1
             if (string.IsNullOrEmpty(usuarioId) || !Guid.TryParse(usuarioId, out var usuarioGuid))
                 return Unauthorized();
 
-            try
-            {
-                var response = await _produtoService.CadastrarProdutoAsync(cadastrarProdutoRequest, usuarioGuid);
-                return Ok(response);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            var response = await _produtoService.CadastrarProdutoAsync(cadastrarProdutoRequest, usuarioGuid);
+            return Ok(response);
         }
 
+        /// <summary>
+        /// Lista todos os produtos cadastrados.
+        /// </summary>
+        /// <returns>Lista de produtos.</returns>
+        /// <response code="200">Produtos retornados com sucesso.</response>
         [HttpGet("BuscarTodosProdutos")]
+        [ProducesResponseType(typeof(IEnumerable<CadastrarProdutoResponse>), StatusCodes.Status200OK)]
         public async Task<IActionResult> TodosProdutosAsync()
         {
             var produtos = await _produtoService.GetAllAsync();
             return Ok(produtos);
         }
 
+        /// <summary>
+        /// Busca um produto específico pelo identificador.
+        /// </summary>
+        /// <param name="id">Identificador do produto.</param>
+        /// <returns>Produto localizado.</returns>
+        /// <response code="200">Produto encontrado.</response>
+        /// <response code="401">Usuário não autenticado.</response>
+        /// <response code="404">Produto não encontrado.</response>
         [Authorize]
         [HttpGet("BuscarProduto/{id:guid}")]
+        [ProducesResponseType(typeof(CadastrarProdutoResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> PuxarIdAsync(Guid id)
         {
-            try
-            {
-                var produto = await _produtoService.GetByIdAsync(id);
-                return Ok(produto);
-            }
-            catch (InvalidOperationException ex)
-            {
-                return NotFound(ex.Message);
-            }
+            var produto = await _produtoService.GetByIdAsync(id);
+            return Ok(produto);
         }
 
+        /// <summary>
+        /// Atualiza os dados de um produto existente.
+        /// </summary>
+        /// <param name="id">Identificador do produto.</param>
+        /// <param name="updateRequest">Novos dados do produto.</param>
+        /// <returns>Produto atualizado.</returns>
+        /// <response code="200">Produto atualizado com sucesso.</response>
+        /// <response code="400">Dados inválidos para atualização.</response>
+        /// <response code="401">Usuário não autenticado.</response>
+        /// <response code="404">Produto não encontrado.</response>
         [Authorize]
         [HttpPut("AtualizarProduto/{id:guid}")]
+        [ProducesResponseType(typeof(AtualizarProdutoResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> AtualizarProdutoAsync(Guid id, [FromBody] AtualizarProdutoRequest updateRequest)
         {
-            try
-            {
-                var produto = await _produtoService.UpdateAsync(id, updateRequest);
-                return Ok(produto);
-            }
-            catch (InvalidOperationException ex)
-            {
-                return NotFound(ex.Message);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            var produto = await _produtoService.UpdateAsync(id, updateRequest);
+            return Ok(produto);
         }
 
+        /// <summary>
+        /// Remove um produto pelo identificador.
+        /// </summary>
+        /// <param name="id">Identificador do produto.</param>
+        /// <response code="204">Produto removido com sucesso.</response>
+        /// <response code="401">Usuário não autenticado.</response>
+        /// <response code="404">Produto não encontrado.</response>
         [Authorize]
-        [HttpDelete("DeletarProduto")]
+        [HttpDelete("DeletarProduto/{id:guid}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> DeletarProdutoAsync(Guid id)
         {
-            try
-            {
-                await _produtoService.DeletarProdutoAsync(id);
-                return NoContent();
-            }
-            catch (InvalidOperationException ex)
-            {
-                return NotFound(ex.Message);
-            }
+            await _produtoService.DeletarProdutoAsync(id);
+            return NoContent();
         }
     }
 }

--- a/ETrocas.API.Internal/Controllers/v1/PropostaController.cs
+++ b/ETrocas.API.Internal/Controllers/v1/PropostaController.cs
@@ -1,18 +1,19 @@
 ﻿using Asp.Versioning;
 using ETrocas.Application.Interfaces;
 using ETrocas.Application.Requests;
+using ETrocas.Application.Responses;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ETrocas.API.Internal.Controllers.v1
 {
+    /// <summary>
+    /// Endpoints para criação de propostas de troca.
+    /// </summary>
     [ApiController]
-    //rota
     [Route("api/v{version:apiVersion}/[controller]")]
-    //controlador herda de Controller
     [ApiVersion("1.0")]
     [Produces("application/json")]
-
     public class PropostaController : Controller
     {
         private readonly IPropostaService _propostaService;
@@ -22,8 +23,22 @@ namespace ETrocas.API.Internal.Controllers.v1
             _propostaService = propostaService;
         }
 
+        /// <summary>
+        /// Cria uma proposta de troca para um produto desejado.
+        /// </summary>
+        /// <param name="id">Identificador do produto desejado (deve ser igual ao ProdutoDesejadoId do corpo).</param>
+        /// <param name="propostaRequest">Dados da proposta de troca.</param>
+        /// <returns>Proposta criada.</returns>
+        /// <response code="200">Proposta criada com sucesso.</response>
+        /// <response code="400">Dados da proposta inválidos.</response>
+        /// <response code="401">Usuário não autenticado.</response>
+        /// <response code="404">Produto não encontrado para proposta.</response>
         [Authorize]
         [HttpPost("FazerProposta/{id:guid}")]
+        [ProducesResponseType(typeof(PropostaResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> FazerProposta(Guid id, [FromBody] PropostaRequest propostaRequest)
         {
             if (id != propostaRequest.ProdutoDesejadoId)
@@ -31,19 +46,8 @@ namespace ETrocas.API.Internal.Controllers.v1
                 return BadRequest("O id da rota deve ser o mesmo ProdutoDesejadoId informado no corpo da requisição.");
             }
 
-            try
-            {
-                var proposta = await _propostaService.FazerPropostaAsync(propostaRequest);
-                return Ok(proposta);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
-            catch (InvalidOperationException ex)
-            {
-                return NotFound(ex.Message);
-            }
+            var proposta = await _propostaService.FazerPropostaAsync(propostaRequest);
+            return Ok(proposta);
         }
     }
 }

--- a/ETrocas.API.Internal/ETrocas.API.Internal.csproj
+++ b/ETrocas.API.Internal/ETrocas.API.Internal.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>20feac41-2f10-41e3-b8b4-a96e20299692</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ETrocas.API.Internal/Middleware/ApiExceptionMiddlewareExtensions.cs
+++ b/ETrocas.API.Internal/Middleware/ApiExceptionMiddlewareExtensions.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+namespace ETrocas.API.Internal.Middleware;
+
+/// <summary>
+/// Middleware global para tratamento padronizado de exceções da API.
+/// </summary>
+public static class ApiExceptionMiddlewareExtensions
+{
+    /// <summary>
+    /// Registra o middleware de tratamento global de exceções.
+    /// </summary>
+    public static IApplicationBuilder UseApiExceptionHandling(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<ApiExceptionMiddleware>();
+    }
+
+    private sealed class ApiExceptionMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ApiExceptionMiddleware> _logger;
+
+        public ApiExceptionMiddleware(RequestDelegate next, ILogger<ApiExceptionMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro não tratado durante o processamento da requisição.");
+                await HandleExceptionAsync(context, ex);
+            }
+        }
+
+        private static async Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            var (statusCode, title) = exception switch
+            {
+                ArgumentException => (StatusCodes.Status400BadRequest, "Requisição inválida"),
+                UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Não autorizado"),
+                InvalidOperationException => (StatusCodes.Status404NotFound, "Recurso não encontrado"),
+                _ => (StatusCodes.Status500InternalServerError, "Erro interno do servidor")
+            };
+
+            var details = new ProblemDetails
+            {
+                Status = statusCode,
+                Title = title,
+                Detail = exception.Message,
+                Instance = context.Request.Path
+            };
+
+            details.Extensions["traceId"] = context.TraceIdentifier;
+
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = statusCode;
+
+            await context.Response.WriteAsync(JsonSerializer.Serialize(details));
+        }
+    }
+}

--- a/ETrocas.API.Internal/Program.cs
+++ b/ETrocas.API.Internal/Program.cs
@@ -1,5 +1,7 @@
+using ETrocas.API.Internal.Middleware;
 using ETrocas.Ioc;
 using Microsoft.OpenApi.Models;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,44 +16,62 @@ builder.Services.AddSwaggerGen(c =>
     {
         Version = "v1",
         Title = "ETrocas",
-        Description = "Sistema de trocas",
+        Description = "API para gestão de trocas, produtos, propostas e autenticação de usuários.",
         TermsOfService = new Uri("https://github.com/Namanosbad"),
-        Contact = new OpenApiContact 
+        Contact = new OpenApiContact
         {
             Name = "Matheus Lima",
             Email = "matheus.limamst@gmail.com",
             Url = new Uri("https://www.linkedin.com/in/matheuslimamst/"),
         }
     });
-    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme()
+
+    var apiXmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var apiXmlPath = Path.Combine(AppContext.BaseDirectory, apiXmlFile);
+    if (File.Exists(apiXmlPath))
+    {
+        c.IncludeXmlComments(apiXmlPath, includeControllerXmlComments: true);
+    }
+
+    var applicationXmlFile = "ETrocas.Application.xml";
+    var applicationXmlPath = Path.Combine(AppContext.BaseDirectory, applicationXmlFile);
+    if (File.Exists(applicationXmlPath))
+    {
+        c.IncludeXmlComments(applicationXmlPath);
+    }
+
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Name = "Authorization",
-        Type = SecuritySchemeType.ApiKey,
-        Scheme = "Bearer",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
         BearerFormat = "JWT",
         In = ParameterLocation.Header,
-        Description = "JWT Authorization header using the Bearer scheme",
+        Description = "Informe o token JWT no formato: Bearer {seu_token}."
     });
+
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
                 {
-                    {
-                          new OpenApiSecurityScheme
-                          {
-                              Reference = new OpenApiReference
-                              {
-                                  Type = ReferenceType.SecurityScheme,
-                                  Id = "Bearer"
-                              }
-                          },
-                         new string[] {}
-                    }
-                });
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
 });
 
 builder.Services.AddServices(builder.Configuration);
 
 
 var app = builder.Build();
+
+app.UseApiExceptionHandling();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/Etrocas.Application/ETrocas.Application.csproj
+++ b/Etrocas.Application/ETrocas.Application.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Etrocas.Application/Requests/AtualizarProdutoRequest.cs
+++ b/Etrocas.Application/Requests/AtualizarProdutoRequest.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Requests;
 
+/// <summary>
+/// Dados utilizados para atualizar um produto.
+/// </summary>
 public class AtualizarProdutoRequest
 {
     public string? Produto { get; set; }

--- a/Etrocas.Application/Requests/CadastrarProdutoRequest.cs
+++ b/Etrocas.Application/Requests/CadastrarProdutoRequest.cs
@@ -1,10 +1,22 @@
 ﻿namespace ETrocas.Application.Requests;
-//o que o usuario precisa colocar
+
+/// <summary>
+/// Dados necessários para cadastro de um produto.
+/// </summary>
 public class CadastrarProdutoRequest
 {
+    /// <summary>Nome do produto.</summary>
     public string? Produto { get; set; }
+
+    /// <summary>Descrição detalhada do produto.</summary>
     public string? Descricao { get; set; }
+
+    /// <summary>Valor de referência do produto.</summary>
     public decimal Valor { get; set; }
+
+    /// <summary>URL da imagem do produto.</summary>
     public string? Imagem { get; set; }
+
+    /// <summary>Categoria ou tipo do produto.</summary>
     public string? Tipo { get; set; }
 }

--- a/Etrocas.Application/Requests/LoginUsuarioRequest.cs
+++ b/Etrocas.Application/Requests/LoginUsuarioRequest.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Requests;
-//pergunta / o que o usuario vai colocar
+
+/// <summary>
+/// Credenciais para autenticação do usuário.
+/// </summary>
 public class LoginUsuarioRequest
 {
     public string Email { get; set; }

--- a/Etrocas.Application/Requests/PropostaRequest.cs
+++ b/Etrocas.Application/Requests/PropostaRequest.cs
@@ -1,7 +1,8 @@
-﻿using ETrocas.Domain.Entities;
+﻿namespace ETrocas.Application.Requests;
 
-namespace ETrocas.Application.Requests;
-
+/// <summary>
+/// Dados para criação de proposta de troca.
+/// </summary>
 public class PropostaRequest
 {
     public Guid ProdutoDesejadoId { get; set; }

--- a/Etrocas.Application/Requests/RegistrarUsuarioRequest.cs
+++ b/Etrocas.Application/Requests/RegistrarUsuarioRequest.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Requests;
 
+/// <summary>
+/// Dados necessários para registrar um usuário.
+/// </summary>
 public class RegistrarUsuarioRequest
 {
     public string Nome { get; set; }

--- a/Etrocas.Application/Responses/AtualizarProdutoResponse.cs
+++ b/Etrocas.Application/Responses/AtualizarProdutoResponse.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Responses;
 
+/// <summary>
+/// Retorno com dados do produto atualizado.
+/// </summary>
 public class AtualizarProdutoResponse
 {
     public Guid Id { get; set; }

--- a/Etrocas.Application/Responses/CadastrarProdutoResponse.cs
+++ b/Etrocas.Application/Responses/CadastrarProdutoResponse.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Responses;
-//o que o swagger vai devolver.
+
+/// <summary>
+/// Dados retornados após operações com produto.
+/// </summary>
 public class CadastrarProdutoResponse
 {
     public Guid UsuarioId { get; set; }
@@ -11,5 +14,4 @@ public class CadastrarProdutoResponse
     public bool Disponivel { get; set; }
     public DateTime DataCadastro { get; set; } = DateTime.Now;
     public string? ImageUrl { get; set; }
-
 }

--- a/Etrocas.Application/Responses/LoginUsuarioResponse.cs
+++ b/Etrocas.Application/Responses/LoginUsuarioResponse.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Responses;
-//resposta/ O que o swagger vai devolver
+
+/// <summary>
+/// Retorno do login com token de acesso.
+/// </summary>
 public class LoginUsuarioResponse
 {
     public Guid Id { get; set; }

--- a/Etrocas.Application/Responses/PropostaResponse.cs
+++ b/Etrocas.Application/Responses/PropostaResponse.cs
@@ -2,7 +2,10 @@
 
 namespace ETrocas.Application.Responses;
 
-    public class PropostaResponse
+/// <summary>
+/// Retorno de proposta criada.
+/// </summary>
+public class PropostaResponse
 {
     public Guid Id { get; set; }
     public EStatusProposta Status { get; set; }

--- a/Etrocas.Application/Responses/RegistrarUsuarioResponse.cs
+++ b/Etrocas.Application/Responses/RegistrarUsuarioResponse.cs
@@ -1,5 +1,8 @@
 ﻿namespace ETrocas.Application.Responses;
 
+/// <summary>
+/// Retorno de cadastro de usuário.
+/// </summary>
 public class RegistrarUsuarioResponse
 {
     public Guid Id { get; set; }


### PR DESCRIPTION
### Motivation
- Provide a single, standardized way to translate exceptions to HTTP `ProblemDetails` responses across the API.
- Improve API documentation by generating XML comments and including them in Swagger so endpoints, requests and responses are better described.
- Make controller surface more explicit for clients by adding `ProducesResponseType` attributes and clearer route signatures.
- Move error handling out of controllers to reduce duplication and rely on a centralized middleware.

### Description
- Added `ApiExceptionMiddleware` and an extension `UseApiExceptionHandling` to map `ArgumentException`, `UnauthorizedAccessException`, `InvalidOperationException` and other exceptions to appropriate `ProblemDetails` with correct status codes and `traceId` in the response body.
- Updated `Program.cs` to register the middleware via `app.UseApiExceptionHandling()`, enhanced Swagger setup to include XML comments from the API and application assemblies, and adjusted the OpenAPI bearer security definition and requirement to use HTTP bearer scheme.
- Annotated controllers (`CadastrarUsuarioController`, `ProdutosController`, `PropostaController`) with XML documentation comments and `ProducesResponseType` attributes, removed local try/catch blocks to rely on middleware, and fixed route signatures (e.g. `DeletarProduto/{id:guid}` and validation in `FazerProposta`).
- Enabled XML documentation generation in `ETrocas.API.Internal.csproj` and `ETrocas.Application.csproj` with `<GenerateDocumentationFile>true</GenerateDocumentationFile>` and added summary comments to request/response DTOs in `Etrocas.Application`.

### Testing
- Built the projects with `dotnet build` (API and Application projects) and the build completed successfully.
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dc21ed008329be4338e45d13f915)