### PR TITLE
Read secrets from environment, remove sensitive values from appsettings, and minor service refactors

### DIFF
--- a/ETrocas.API.Internal/appsettings.json
+++ b/ETrocas.API.Internal/appsettings.json
@@ -6,10 +6,10 @@
     }
   },
   "DbConfig": {
-    "ConnectionString": "Server=host.docker.internal,1433;Database=ETrocasDb;User Id=sa;Password=StrongPass!123;TrustServerCertificate=true;"
+    "ConnectionString": ""
   },
   "TokenConfig": {
-    "Key": "7A&n$Gk9@qLtZr!BfX2#CmW8dPvR6uHe"
+    "Key": ""
   },
   "CorsConfig": {
     "AllowedOrigins": [

--- a/ETrocas.Ioc/ServiceCollectionExtensions.cs
+++ b/ETrocas.Ioc/ServiceCollectionExtensions.cs
@@ -39,7 +39,14 @@ namespace ETrocas.Ioc
             services.AddDbContext<ETrocasDbContext>((serviceProvider, options) =>
             {
                 var config = serviceProvider.GetRequiredService<IOptions<DbConfig>>().Value;
-                var connectionString = config.ConnectionString;
+                var envConnectionString = Environment.GetEnvironmentVariable("ETROCAS_DB_CONNECTION_STRING");
+                var connectionString = string.IsNullOrWhiteSpace(envConnectionString)
+                    ? config.ConnectionString
+                    : envConnectionString;
+
+                if (string.IsNullOrWhiteSpace(connectionString))
+                    throw new InvalidOperationException("A connection string não foi configurada.");
+
                 options.UseSqlServer(connectionString);
             });
 
@@ -80,7 +87,14 @@ namespace ETrocas.Ioc
                 x.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
             }).AddJwtBearer(x =>
             {
-                var key = configuration["TokenConfig:Key"];
+                var envKey = Environment.GetEnvironmentVariable("ETROCAS_TOKEN_KEY");
+                var key = string.IsNullOrWhiteSpace(envKey)
+                    ? configuration["TokenConfig:Key"]
+                    : envKey;
+
+                if (string.IsNullOrWhiteSpace(key))
+                    throw new InvalidOperationException("A chave JWT não foi configurada.");
+
                 var asciiKey = Encoding.ASCII.GetBytes(key!);
 
                 x.TokenValidationParameters = new TokenValidationParameters

--- a/ETrocas.Shared/Configuration/DbConfig.cs
+++ b/ETrocas.Shared/Configuration/DbConfig.cs
@@ -2,5 +2,5 @@
 
 public class DbConfig
 {
-    public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; } = string.Empty;
 }

--- a/ETrocas.Shared/Configuration/TokenConfig.cs
+++ b/ETrocas.Shared/Configuration/TokenConfig.cs
@@ -2,5 +2,5 @@
 
 public class TokenConfig
 {
-    public string Key { get; set; }
+    public string Key { get; set; } = string.Empty;
 }

--- a/ETrocas.Shared/Services/TokenService.cs
+++ b/ETrocas.Shared/Services/TokenService.cs
@@ -13,11 +13,17 @@ namespace ETrocas.Shared.Services
     public class TokenService(IOptions<TokenConfig> config) : ITokenService
     {
         private readonly TokenConfig _config = config.Value;
+        private readonly string? _envTokenKey = Environment.GetEnvironmentVariable("ETROCAS_TOKEN_KEY");
 
         public string Gerar(Usuario usuario)
         {
             var handler = new JwtSecurityTokenHandler();
-            var key = Encoding.ASCII.GetBytes(_config.Key);
+            var tokenKey = string.IsNullOrWhiteSpace(_envTokenKey) ? _config.Key : _envTokenKey;
+
+            if (string.IsNullOrWhiteSpace(tokenKey))
+                throw new InvalidOperationException("A chave JWT não foi configurada.");
+
+            var key = Encoding.ASCII.GetBytes(tokenKey);
             var credentials = new SigningCredentials(
                                                      new SymmetricSecurityKey(key),
                                                      SecurityAlgorithms.HmacSha256Signature

--- a/Etrocas.Application/Services/v1/ProdutoService.cs
+++ b/Etrocas.Application/Services/v1/ProdutoService.cs
@@ -3,13 +3,11 @@ using ETrocas.Application.Requests;
 using ETrocas.Application.Responses;
 using ETrocas.Domain.Entities;
 using ETrocas.Domain.Interfaces;
-//logica do negocio
+
 namespace ETrocas.Application.Services.v1
 {
-    //herda da interface
     public class ProdutoService : IProdutoService
     {
-        //injeção de dependencia
         private readonly IProdutoRepository _produtoRepository;
         private readonly IRepository<Produtos> _repo;
 
@@ -19,7 +17,6 @@ namespace ETrocas.Application.Services.v1
             _repo = repo;
         }
 
-        //logica do cadastro de produto.
         public async Task<CadastrarProdutoResponse> CadastrarProdutoAsync(CadastrarProdutoRequest cadastrarProdutoRequest, Guid usuarioGuid)
         {
             if (cadastrarProdutoRequest == null)
@@ -29,8 +26,7 @@ namespace ETrocas.Application.Services.v1
                 string.IsNullOrWhiteSpace(cadastrarProdutoRequest.Tipo))
                 throw new ArgumentException("Produto e tipo são obrigatórios.");
 
-            //Aqui eu cadastro o produto a linha 23 é o objeto de entrada que representa o request.
-            var CadastrarProduto = new Produtos
+            var produtoParaCadastro = new Produtos
             {
                 Id = Guid.NewGuid(),
                 Produto = cadastrarProdutoRequest.Produto,
@@ -42,26 +38,23 @@ namespace ETrocas.Application.Services.v1
                 Tipo = cadastrarProdutoRequest.Tipo
             };
 
-            //Aqui eu salvo no banco esse produto cadastrado. Uso o _produtoRepository e o metodo no banco para lidar com o banco 
-            var ProdutoCriado = await _produtoRepository.CadastrarProdutoAsync(CadastrarProduto);
+            var produtoCriado = await _produtoRepository.CadastrarProdutoAsync(produtoParaCadastro);
 
-            //O que vai retornar pro usuario.
             return new CadastrarProdutoResponse
             {
-                Id = ProdutoCriado.Id,
-                Produto = ProdutoCriado.Produto,
-                Tipo = ProdutoCriado.Tipo,
-                Valor = ProdutoCriado.Valor,
-                Descricao = ProdutoCriado.Descricao,
-                Disponivel = ProdutoCriado.Disponivel,
-                DataCadastro = ProdutoCriado.DataCadastro,
-                ImageUrl = ProdutoCriado.ImageUrl,
-                UsuarioId = ProdutoCriado.UsuarioId,
+                Id = produtoCriado.Id,
+                Produto = produtoCriado.Produto,
+                Tipo = produtoCriado.Tipo,
+                Valor = produtoCriado.Valor,
+                Descricao = produtoCriado.Descricao,
+                Disponivel = produtoCriado.Disponivel,
+                DataCadastro = produtoCriado.DataCadastro,
+                ImageUrl = produtoCriado.ImageUrl,
+                UsuarioId = produtoCriado.UsuarioId,
             };
         }
 
 
-        //logica para deletar um produto.
         public async Task DeletarProdutoAsync(Guid id)
         {
 
@@ -72,7 +65,6 @@ namespace ETrocas.Application.Services.v1
             await _repo.DeleteAsync(id);
         }
 
-        //logica para puxar produto pelo Id
         public async Task<Produtos> GetByIdAsync(Guid id)
         {
             var produto = await _repo.GetByIdAsync(id);
@@ -81,26 +73,22 @@ namespace ETrocas.Application.Services.v1
             return produto;
         }
 
-        //logica para puxar todos os produtos.
         public async Task<IEnumerable<Produtos>> GetAllAsync()
         {
             var produtos = await _repo.GetAllAsync();
             return produtos;
         }
 
-        //logica para atualizar produtos cadastrados.
         public async Task<AtualizarProdutoResponse> UpdateAsync(Guid id, AtualizarProdutoRequest updateRequest)
         {
             if (updateRequest == null)
                 throw new ArgumentNullException(nameof(updateRequest));
 
-            //1- encontrar pelo id.
             var produto = await _repo.GetByIdAsync(id);
 
             if (produto == null)
                 throw new InvalidOperationException("Produto nao encontrado.");
 
-            //2- request,
             produto.Produto = updateRequest.Produto;
             produto.Tipo = updateRequest.Tipo;
             produto.Valor = updateRequest.Valor;
@@ -108,10 +96,8 @@ namespace ETrocas.Application.Services.v1
             produto.Disponivel = updateRequest.Disponivel;
             produto.ImageUrl = updateRequest.ImageUrl;
 
-            //faz o update
             await _repo.UpdateAsync(produto);
 
-            //3-response,//4- retorno.
             return new AtualizarProdutoResponse
             {
                 Id = produto.Id,

--- a/README.md
+++ b/README.md
@@ -1,45 +1,45 @@
-# 📦 ETrocas - (em desenvolvimento)
+# 📦 ETrocas
 
-Sistema de **trocas de produtos** desenvolvido em **.NET 8** com
-arquitetura em camadas, pensado para oferecer uma forma prática, segura e organizada de negociar bens entre usuários.
+Sistema de **trocas de produtos** desenvolvido em **.NET 8** com arquitetura em camadas, pensado para oferecer uma forma prática, segura e organizada de negociar bens entre usuários.
 
-A aplicação permite que pessoas cadastrem seus produtos e façam propostas de troca. A aplicação possibilita aceitar ou recusar ofertas, acompanhar o histórico de negociações e manter todo o processo de troca documentado e transparente.
+A aplicação permite que pessoas cadastrem seus produtos e façam propostas de troca. Também possibilita aceitar ou recusar ofertas, acompanhar o histórico de negociações e manter todo o processo de troca documentado e transparente.
 
 O projeto foi construído com foco em boas práticas de desenvolvimento, separação de responsabilidades e escalabilidade.
 
-O objetivo principal do ETrocas é demonstrar na prática como aplicar arquitetura limpa em um sistema real, promovendo código de fácil manutenção e com potencial de crescimento para novas funcionalidades.
 ------------------------------------------------------------------------
 
 ## 🚀 Tecnologias Utilizadas
 
--   **ASP.NET Core 8 (Web API)**
--   **Entity Framework Core 8**
--   **SQL Server**
--   **JWT (Bearer Token)**
--   **Swagger / OpenAPI**
--   **Arquitetura em Camadas (Domain, Database, Application, API, IoC, Shared)**
+- **ASP.NET Core 8 (Web API)**
+- **Entity Framework Core 8**
+- **SQL Server**
+- **JWT (Bearer Token)**
+- **Swagger / OpenAPI**
+- **Arquitetura em Camadas (Domain, Database, Application, API, IoC, Shared)**
 
 ------------------------------------------------------------------------
 
 ## 📂 Estrutura do Projeto (pastas reais)
 
-    ETrocas/
-    │── ETrocas.API.Internal/   # API (controllers, Program, configs)
-    │── Etrocas.Application/    # Serviços, requests e responses
-    │── ETrocas.Database/       # DbContext, repositórios e migrations
-    │── ETrocas.Domain/         # Entidades e interfaces de domínio
-    │── ETrocas.Ioc/            # Injeção de dependências e configuração de serviços
-    │── ETrocas.Shared/         # Configurações e serviços compartilhados
+```text
+ETrocas/
+│── ETrocas.API.Internal/   # API (controllers, Program, configs)
+│── Etrocas.Application/    # Serviços, requests e responses
+│── ETrocas.Database/       # DbContext, repositórios e migrations
+│── ETrocas.Domain/         # Entidades e interfaces de domínio
+│── ETrocas.Ioc/            # Injeção de dependências e configuração de serviços
+│── ETrocas.Shared/         # Configurações e serviços compartilhados
+```
 
 ------------------------------------------------------------------------
 
 ## 🔑 Funcionalidades Principais
 
--   Cadastro e autenticação de usuários
--   Cadastro, atualização, consulta e remoção de produtos
--   Criação de propostas de troca
--   Versionamento de API (`v1`)
--   Autenticação com JWT em rotas protegidas
+- Cadastro e autenticação de usuários
+- Cadastro, atualização, consulta e remoção de produtos
+- Criação de propostas de troca
+- Versionamento de API (`v1`)
+- Autenticação com JWT em rotas protegidas
 
 ------------------------------------------------------------------------
 
@@ -52,12 +52,28 @@ git clone https://github.com/Namanosbad/ETrocas.git
 cd ETrocas
 ```
 
-### 2️⃣ Configurar o Banco de Dados
+### 2️⃣ Configurar segredos (recomendado)
 
-No arquivo `ETrocas.API.Internal/appsettings.json`, configure:
+A API agora prioriza variáveis de ambiente para configurações sensíveis:
 
-- `DbConfig:ConnectionString`
-- `TokenConfig:Key`
+- `ETROCAS_DB_CONNECTION_STRING`
+- `ETROCAS_TOKEN_KEY`
+
+Exemplo Linux/macOS:
+
+```bash
+export ETROCAS_DB_CONNECTION_STRING="Server=localhost,1433;Database=ETrocasDb;User Id=sa;Password=SuaSenha;TrustServerCertificate=true;"
+export ETROCAS_TOKEN_KEY="SUA_CHAVE_JWT_FORTE_AQUI"
+```
+
+Exemplo PowerShell:
+
+```powershell
+$env:ETROCAS_DB_CONNECTION_STRING = "Server=localhost,1433;Database=ETrocasDb;User Id=sa;Password=SuaSenha;TrustServerCertificate=true;"
+$env:ETROCAS_TOKEN_KEY = "SUA_CHAVE_JWT_FORTE_AQUI"
+```
+
+> Em desenvolvimento local, você também pode preencher `DbConfig:ConnectionString` e `TokenConfig:Key` em arquivos de configuração locais não versionados.
 
 ### 3️⃣ Executar as Migrations
 
@@ -80,27 +96,26 @@ A API estará disponível conforme as URLs definidas em:
 
 ### Usuário (`CadastrarUsuarioController`)
 
--   `POST /api/v1/CadastrarUsuario/registrar`
--   `POST /api/v1/CadastrarUsuario/login`
+- `POST /api/v1/CadastrarUsuario/registrar`
+- `POST /api/v1/CadastrarUsuario/login`
 
 ### Produtos (`ProdutosController`)
 
--   `POST /api/v1/Produtos/CadastrarProduto` (autenticado)
--   `GET /api/v1/Produtos/BuscarTodosProdutos`
--   `GET /api/v1/Produtos/BuscarProduto/{id}` (autenticado)
--   `PUT /api/v1/Produtos/AtualizarProduto/{id}` (autenticado)
--   `DELETE /api/v1/Produtos/DeletarProduto?id={id}` (autenticado)
+- `POST /api/v1/Produtos/CadastrarProduto` (autenticado)
+- `GET /api/v1/Produtos/BuscarTodosProdutos`
+- `GET /api/v1/Produtos/BuscarProduto/{id}` (autenticado)
+- `PUT /api/v1/Produtos/AtualizarProduto/{id}` (autenticado)
+- `DELETE /api/v1/Produtos/DeletarProduto/{id}` (autenticado)
 
 ### Propostas (`PropostaController`)
 
--   `POST /api/v1/Proposta/FazerProposta/{id}` (autenticado)
+- `POST /api/v1/Proposta/FazerProposta/{id}` (autenticado)
 
 ------------------------------------------------------------------------
 
 ## 🐳 Docker
 
-Atualmente o repositório contém apenas o `Dockerfile` da API em
-`ETrocas.API.Internal/Dockerfile`.
+Atualmente o repositório contém apenas o `Dockerfile` da API em `ETrocas.API.Internal/Dockerfile`.
 
 > Não há arquivo `docker-compose.yml` versionado neste momento.
 


### PR DESCRIPTION
### Motivation
- Avoid committing sensitive configuration into source control by prioritizing environment variables for database and JWT secrets.
- Fail fast on startup when required secrets are missing to make configuration issues visible early.
- Clean up service code and README to reflect the new configuration approach and improve code readability.

### Description
- Cleared sensitive values in `ETrocas.API.Internal/appsettings.json` for `DbConfig:ConnectionString` and `TokenConfig:Key` and documented environment variables in `README.md` (`ETROCAS_DB_CONNECTION_STRING` and `ETROCAS_TOKEN_KEY`).
- Updated dependency registration in `ETrocas.Ioc/ServiceCollectionExtensions.cs` to prefer environment variables (`ETROCAS_DB_CONNECTION_STRING` and `ETROCAS_TOKEN_KEY`) and to throw an `InvalidOperationException` when the resolved connection string or token key is empty.
- Updated `ETrocas.Shared` config classes to initialize `ConnectionString` and `Key` to empty strings and changed `ETrocas.Shared/Services/TokenService.cs` to read the `ETROCAS_TOKEN_KEY` environment variable and validate it before generating tokens.
- Minor refactor in `Etrocas.Application/Services/v1/ProdutoService.cs` to rename variables for clarity and remove inline comment noise.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e10ec9dc8329a98415c5fa77046b)