### PR TITLE
Enforce product ownership for update/delete and tighten CORS origin validation

### DIFF
--- a/ETrocas.API.Internal/Controllers/v1/ProdutosController.cs
+++ b/ETrocas.API.Internal/Controllers/v1/ProdutosController.cs
@@ -98,7 +98,12 @@ namespace ETrocas.API.Internal.Controllers.v1
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> AtualizarProdutoAsync(Guid id, [FromBody] AtualizarProdutoRequest updateRequest)
         {
-            var produto = await _produtoService.UpdateAsync(id, updateRequest);
+            var usuarioId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(usuarioId) || !Guid.TryParse(usuarioId, out var usuarioGuid))
+                return Unauthorized();
+
+            var produto = await _produtoService.UpdateAsync(id, updateRequest, usuarioGuid);
             return Ok(produto);
         }
 
@@ -116,7 +121,12 @@ namespace ETrocas.API.Internal.Controllers.v1
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> DeletarProdutoAsync(Guid id)
         {
-            await _produtoService.DeletarProdutoAsync(id);
+            var usuarioId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(usuarioId) || !Guid.TryParse(usuarioId, out var usuarioGuid))
+                return Unauthorized();
+
+            await _produtoService.DeletarProdutoAsync(id, usuarioGuid);
             return NoContent();
         }
     }

--- a/ETrocas.Ioc/ServiceCollectionExtensions.cs
+++ b/ETrocas.Ioc/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using System.Linq;
 using System.Text;
 
 namespace ETrocas.Ioc
@@ -60,18 +61,22 @@ namespace ETrocas.Ioc
 
             var allowedOrigins = configuration
                 .GetSection($"{nameof(CorsConfig)}:{nameof(CorsConfig.AllowedOrigins)}")
-                .Get<string[]>() ?? [];
+                .Get<string[]>()
+                ?.Where(origin => !string.IsNullOrWhiteSpace(origin))
+                .Select(origin => origin.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? [];
+
+            if (allowedOrigins.Length == 0)
+                throw new InvalidOperationException("CorsConfig:AllowedOrigins deve conter ao menos uma origem válida para a política RestrictedCors.");
 
             services.AddCors(options =>
             {
                 options.AddPolicy("RestrictedCors", policy =>
                 {
-                    if (allowedOrigins.Length > 0)
-                    {
-                        policy.WithOrigins(allowedOrigins)
-                            .AllowAnyHeader()
-                            .AllowAnyMethod();
-                    }
+                    policy.WithOrigins(allowedOrigins)
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
                 });
             });
 

--- a/Etrocas.Application/Interfaces/IProdutoService.cs
+++ b/Etrocas.Application/Interfaces/IProdutoService.cs
@@ -7,8 +7,8 @@ namespace ETrocas.Application.Interfaces;
 public interface IProdutoService
 {
     Task<CadastrarProdutoResponse> CadastrarProdutoAsync(CadastrarProdutoRequest cadastrarProdutoRequest, Guid usuarioGuid);
-    Task DeletarProdutoAsync(Guid id);
+    Task DeletarProdutoAsync(Guid id, Guid usuarioGuid);
     Task<Produtos> GetByIdAsync(Guid id);
     Task<IEnumerable<Produtos>> GetAllAsync();
-    Task<AtualizarProdutoResponse> UpdateAsync(Guid id, AtualizarProdutoRequest updateRequest);
+    Task<AtualizarProdutoResponse> UpdateAsync(Guid id, AtualizarProdutoRequest updateRequest, Guid usuarioGuid);
 }

--- a/Etrocas.Application/Services/v1/ProdutoService.cs
+++ b/Etrocas.Application/Services/v1/ProdutoService.cs
@@ -55,12 +55,14 @@ namespace ETrocas.Application.Services.v1
         }
 
 
-        public async Task DeletarProdutoAsync(Guid id)
+        public async Task DeletarProdutoAsync(Guid id, Guid usuarioGuid)
         {
-
-            var exist = await _repo.ExistAsync(id);
-            if (!exist)
+            var produto = await _repo.GetByIdAsync(id);
+            if (produto == null)
                 throw new InvalidOperationException("Produto nao encontrado.");
+
+            if (produto.UsuarioId != usuarioGuid)
+                throw new UnauthorizedAccessException("Você não tem permissão para excluir este produto.");
 
             await _repo.DeleteAsync(id);
         }
@@ -79,7 +81,7 @@ namespace ETrocas.Application.Services.v1
             return produtos;
         }
 
-        public async Task<AtualizarProdutoResponse> UpdateAsync(Guid id, AtualizarProdutoRequest updateRequest)
+        public async Task<AtualizarProdutoResponse> UpdateAsync(Guid id, AtualizarProdutoRequest updateRequest, Guid usuarioGuid)
         {
             if (updateRequest == null)
                 throw new ArgumentNullException(nameof(updateRequest));
@@ -88,6 +90,9 @@ namespace ETrocas.Application.Services.v1
 
             if (produto == null)
                 throw new InvalidOperationException("Produto nao encontrado.");
+
+            if (produto.UsuarioId != usuarioGuid)
+                throw new UnauthorizedAccessException("Você não tem permissão para alterar este produto.");
 
             produto.Produto = updateRequest.Produto;
             produto.Tipo = updateRequest.Tipo;


### PR DESCRIPTION
### Motivation
- Prevent users from updating or deleting products they don't own by propagating the authenticated user id to service layer and enforcing ownership checks.
- Harden CORS configuration by normalizing and validating configured origins and failing startup when none are provided.

### Description
- Updated `ProdutosController` to extract `ClaimTypes.NameIdentifier` as a `Guid` and return `Unauthorized()` when missing, and passed the `usuarioGuid` into the service calls for `UpdateAsync` and `DeletarProdutoAsync`.
- Extended `IProdutoService` signatures for `UpdateAsync` and `DeletarProdutoAsync` to accept a `Guid usuarioGuid` parameter.
- Implemented ownership checks in `ProdutoService` by loading the product with `_repo.GetByIdAsync`, throwing `InvalidOperationException` if not found and `UnauthorizedAccessException` if the `UsuarioId` does not match `usuarioGuid`, and then performing the update or delete.
- Improved DI setup in `ServiceCollectionExtensions` by trimming, filtering and deduplicating `CorsConfig:AllowedOrigins`, throwing an `InvalidOperationException` if no valid origins are configured, and always applying the origins to the `RestrictedCors` policy.

### Testing
- No automated tests were executed as part of this rollout; changes were limited to API/ service code and DI configuration and should be covered by existing unit/integration tests when run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e600c2f08329925bef0684d4f792)