### PR TITLE
Corrige exceção de chave JWT ausente em Development usando fallback

### DIFF
--- a/ETrocas.Ioc/ServiceCollectionExtensions.cs
+++ b/ETrocas.Ioc/ServiceCollectionExtensions.cs
@@ -22,6 +22,8 @@ namespace ETrocas.Ioc
 {
     public static class ServiceCollectionExtensions
     {
+        private const string DevelopmentFallbackJwtKey = "ETrocas-Dev-Only-Jwt-Key-Change-In-Production";
+
         public static IServiceCollection AddServices(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddDbContext(configuration);
@@ -96,6 +98,12 @@ namespace ETrocas.Ioc
                 var key = string.IsNullOrWhiteSpace(envKey)
                     ? configuration["TokenConfig:Key"]
                     : envKey;
+
+                var environment = configuration["ASPNETCORE_ENVIRONMENT"];
+                var isDevelopmentEnvironment = string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
+
+                if (string.IsNullOrWhiteSpace(key) && isDevelopmentEnvironment)
+                    key = DevelopmentFallbackJwtKey;
 
                 if (string.IsNullOrWhiteSpace(key))
                     throw new InvalidOperationException("A chave JWT não foi configurada.");

--- a/ETrocas.Shared/Services/TokenService.cs
+++ b/ETrocas.Shared/Services/TokenService.cs
@@ -12,13 +12,21 @@ namespace ETrocas.Shared.Services
 {
     public class TokenService(IOptions<TokenConfig> config) : ITokenService
     {
+        private const string DevelopmentFallbackJwtKey = "ETrocas-Dev-Only-Jwt-Key-Change-In-Production";
+
         private readonly TokenConfig _config = config.Value;
         private readonly string? _envTokenKey = Environment.GetEnvironmentVariable("ETROCAS_TOKEN_KEY");
+        private readonly string? _aspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 
         public string Gerar(Usuario usuario)
         {
             var handler = new JwtSecurityTokenHandler();
             var tokenKey = string.IsNullOrWhiteSpace(_envTokenKey) ? _config.Key : _envTokenKey;
+
+            var isDevelopmentEnvironment = string.Equals(_aspNetCoreEnvironment, "Development", StringComparison.OrdinalIgnoreCase);
+
+            if (string.IsNullOrWhiteSpace(tokenKey) && isDevelopmentEnvironment)
+                tokenKey = DevelopmentFallbackJwtKey;
 
             if (string.IsNullOrWhiteSpace(tokenKey))
                 throw new InvalidOperationException("A chave JWT não foi configurada.");


### PR DESCRIPTION
### Motivation
- O startup e a geração de tokens lançavam `InvalidOperationException("A chave JWT não foi configurada.")` mesmo em cenários de desenvolvimento local sem `TokenConfig:Key` ou `ETROCAS_TOKEN_KEY` configurados.
- Isso fazia endpoints públicos ou fluxos de desenvolvimento quebrarem desnecessariamente ao não haver chave JWT definida.
- A intenção é permitir execução local/Dev sem exigir configuração de chave, mantendo comportamento rígido em outros ambientes.

### Description
- Adicionei a constante `DevelopmentFallbackJwtKey` em `ETrocas.Ioc/ServiceCollectionExtensions.cs` e em `ETrocas.Shared/Services/TokenService.cs` como chave de fallback para Development.
- Passei a ler `ASPNETCORE_ENVIRONMENT` e a aplicar o fallback somente quando o ambiente for `Development` e a chave efetiva estiver vazia, em `AddAuthentication` (validação) e em `TokenService.Gerar` (emissão).
- Mantive a lógica de lançar `InvalidOperationException("A chave JWT não foi configurada.")` para ambientes que não sejam `Development` quando não houver chave configurada.

### Testing
- Executei `dotnet build ETrocas.sln` como teste automatizado de build e ele falhou devido ao ambiente não ter o `dotnet` instalado (erro: `bash: command not found: dotnet`).
- Não foram executados outros testes automatizados neste ambiente por falta do runtime/tooling necessário.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2768b9888329865df0b1ea2bf717)