### PR TITLE
Implement complete proposal flow: endpoints, service/repository logic, migration and model updates

### DIFF
--- a/ETrocas.API.Internal/Controllers/v1/PropostasController.cs
+++ b/ETrocas.API.Internal/Controllers/v1/PropostasController.cs
@@ -2,18 +2,21 @@
 using ETrocas.Application.Interfaces;
 using ETrocas.Application.Requests;
 using ETrocas.Application.Responses;
+using ETrocas.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace ETrocas.API.Internal.Controllers.v1
 {
     /// <summary>
-    /// Endpoints para criação de propostas de troca.
+    /// Endpoints de propostas de troca.
     /// </summary>
     [ApiController]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion("1.0")]
     [Produces("application/json")]
+    [Authorize]
     public class PropostasController : ControllerBase
     {
         private readonly IPropostaService _propostaService;
@@ -23,17 +26,6 @@ namespace ETrocas.API.Internal.Controllers.v1
             _propostaService = propostaService;
         }
 
-        /// <summary>
-        /// Cria uma proposta de troca para um produto desejado.
-        /// </summary>
-        /// <param name="id">Identificador do produto desejado (deve ser igual ao ProdutoDesejadoId do corpo).</param>
-        /// <param name="propostaRequest">Dados da proposta de troca.</param>
-        /// <returns>Proposta criada.</returns>
-        /// <response code="200">Proposta criada com sucesso.</response>
-        /// <response code="400">Dados da proposta inválidos.</response>
-        /// <response code="401">Usuário não autenticado.</response>
-        /// <response code="404">Produto não encontrado para proposta.</response>
-        [Authorize]
         [HttpPost("{id:guid}")]
         [ProducesResponseType(typeof(PropostaResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -46,8 +38,68 @@ namespace ETrocas.API.Internal.Controllers.v1
                 return BadRequest("O id da rota deve ser o mesmo ProdutoDesejadoId informado no corpo da requisição.");
             }
 
-            var proposta = await _propostaService.FazerPropostaAsync(propostaRequest);
+            if (!TryGetUsuarioId(out var usuarioId))
+            {
+                return Unauthorized();
+            }
+
+            var proposta = await _propostaService.FazerPropostaAsync(propostaRequest, usuarioId);
             return Ok(proposta);
+        }
+
+        [HttpGet("enviadas")]
+        [ProducesResponseType(typeof(IReadOnlyCollection<PropostaResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> ListarEnviadas()
+        {
+            if (!TryGetUsuarioId(out var usuarioId))
+            {
+                return Unauthorized();
+            }
+
+            var propostas = await _propostaService.ListarEnviadasAsync(usuarioId);
+            return Ok(propostas);
+        }
+
+        [HttpGet("recebidas")]
+        [ProducesResponseType(typeof(IReadOnlyCollection<PropostaResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> ListarRecebidas()
+        {
+            if (!TryGetUsuarioId(out var usuarioId))
+            {
+                return Unauthorized();
+            }
+
+            var propostas = await _propostaService.ListarRecebidasAsync(usuarioId);
+            return Ok(propostas);
+        }
+
+        [HttpPut("{id:guid}/status")]
+        [ProducesResponseType(typeof(PropostaResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> AtualizarStatus(Guid id, [FromBody] AtualizarStatusPropostaRequest request)
+        {
+            if (!TryGetUsuarioId(out var usuarioId))
+            {
+                return Unauthorized();
+            }
+
+            if (request.Status == EStatusProposta.Pendente)
+            {
+                return BadRequest("Não é permitido retornar uma proposta para o status Pendente.");
+            }
+
+            var proposta = await _propostaService.AtualizarStatusAsync(id, usuarioId, request.Status);
+            return Ok(proposta);
+        }
+
+        private bool TryGetUsuarioId(out Guid usuarioId)
+        {
+            usuarioId = Guid.Empty;
+            var usuarioClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            return !string.IsNullOrWhiteSpace(usuarioClaim) && Guid.TryParse(usuarioClaim, out usuarioId);
         }
     }
 }

--- a/ETrocas.Database/EntitiesConfiguration/PropostaEntityConfiguration.cs
+++ b/ETrocas.Database/EntitiesConfiguration/PropostaEntityConfiguration.cs
@@ -12,37 +12,42 @@ namespace ETrocas.Database.EntitiesConfiguration
             builder.HasKey(p => p.Id);
 
             builder.Property(p => p.Id)
-                         .IsRequired()
-                         .ValueGeneratedOnAdd();
+                .IsRequired()
+                .ValueGeneratedOnAdd();
 
             builder.Property(p => p.DataProposta)
-                        .IsRequired();
+                .IsRequired();
 
             builder.Property(p => p.DataResposta)
-                        .IsRequired();
+                .IsRequired(false);
 
             builder.Property(p => p.StatusProposta)
-                        .IsRequired();
+                .IsRequired();
 
-            builder.Property(p =>p.ValorProposto)
-                        .IsRequired();
+            builder.Property(p => p.ValorProposto)
+                .IsRequired();
 
             builder.Property(p => p.Mensagem);
 
             builder.HasOne(p => p.ProdutoDesejado)
-                         .WithMany()
-                         .HasForeignKey(p => p.ProdutoDesejadoId)
-                         .OnDelete(DeleteBehavior.Restrict);
+                .WithMany()
+                .HasForeignKey(p => p.ProdutoDesejadoId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             builder.HasOne(p => p.ProdutoOfertado)
-                         .WithMany()
-                         .HasForeignKey(p => p.ProdutoOfertadoId)
-                         .OnDelete(DeleteBehavior.Restrict);
+                .WithMany()
+                .HasForeignKey(p => p.ProdutoOfertadoId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             builder.HasOne(p => p.UsuarioProposta)
-                         .WithMany(u => u.PropostasFeitas)
-                         .HasForeignKey(p => p.UsuarioPropostaId)
-                         .OnDelete(DeleteBehavior.Restrict);
+                .WithMany(u => u.PropostasFeitas)
+                .HasForeignKey(p => p.UsuarioPropostaId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasOne(p => p.UsuarioRecebedor)
+                .WithMany(u => u.PropostasRecebidas)
+                .HasForeignKey(p => p.UsuarioRecebedorId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/ETrocas.Database/EntitiesConfiguration/UsuarioEntityConfiguration.cs
+++ b/ETrocas.Database/EntitiesConfiguration/UsuarioEntityConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using ETrocas.Domain.Entities;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace ETrocas.Database.EntitiesConfiguration
 {
@@ -12,30 +12,35 @@ namespace ETrocas.Database.EntitiesConfiguration
             builder.HasKey(x => x.Id);
 
             builder.Property(i => i.Id)
-                                    .IsRequired()
-                                    .ValueGeneratedOnAdd();
+                .IsRequired()
+                .ValueGeneratedOnAdd();
 
             builder.Property(i => i.Nome)
-                                    .IsRequired()
-                                    .HasMaxLength(100);
+                .IsRequired()
+                .HasMaxLength(100);
 
             builder.Property(i => i.Email)
-                                    .IsRequired()
-                                    .HasMaxLength(100);
+                .IsRequired()
+                .HasMaxLength(100);
 
             builder.Property(i => i.SenhaHash)
-                                    .IsRequired()
-                                    .HasMaxLength(100);
+                .IsRequired()
+                .HasMaxLength(100);
 
             builder.HasMany(u => u.Produtos)
-                                    .WithOne(p=> p.Usuario)
-                                    .HasForeignKey(p=> p.UsuarioId)
-                                    .OnDelete(DeleteBehavior.Restrict);
+                .WithOne(p => p.Usuario)
+                .HasForeignKey(p => p.UsuarioId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             builder.HasMany(u => u.PropostasFeitas)
-                                    .WithOne(p=> p.UsuarioProposta)
-                                    .HasForeignKey(p => p.UsuarioPropostaId)
-                                    .OnDelete(DeleteBehavior.Restrict);
+                .WithOne(p => p.UsuarioProposta)
+                .HasForeignKey(p => p.UsuarioPropostaId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.HasMany(u => u.PropostasRecebidas)
+                .WithOne(p => p.UsuarioRecebedor)
+                .HasForeignKey(p => p.UsuarioRecebedorId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/ETrocas.Database/Migrations/20260312100000_PropostaFluxoCompleto.cs
+++ b/ETrocas.Database/Migrations/20260312100000_PropostaFluxoCompleto.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ETrocas.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class PropostaFluxoCompleto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "UsuarioRecebedorId",
+                table: "proposta",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: Guid.Empty);
+
+            migrationBuilder.Sql(@"
+                UPDATE p
+                SET p.UsuarioRecebedorId = prod.UsuarioId
+                FROM proposta p
+                INNER JOIN produtos prod ON p.ProdutoDesejadoId = prod.Id
+            ");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DataResposta",
+                table: "proposta",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_proposta_usuario_UsuarioId",
+                table: "proposta");
+
+            migrationBuilder.DropIndex(
+                name: "IX_proposta_UsuarioId",
+                table: "proposta");
+
+            migrationBuilder.DropColumn(
+                name: "UsuarioId",
+                table: "proposta");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_proposta_UsuarioRecebedorId",
+                table: "proposta",
+                column: "UsuarioRecebedorId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_proposta_usuario_UsuarioRecebedorId",
+                table: "proposta",
+                column: "UsuarioRecebedorId",
+                principalTable: "usuario",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_proposta_usuario_UsuarioRecebedorId",
+                table: "proposta");
+
+            migrationBuilder.DropIndex(
+                name: "IX_proposta_UsuarioRecebedorId",
+                table: "proposta");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "UsuarioId",
+                table: "proposta",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE p
+                SET p.UsuarioId = p.UsuarioRecebedorId
+                FROM proposta p
+            ");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DataResposta",
+                table: "proposta",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.DropColumn(
+                name: "UsuarioRecebedorId",
+                table: "proposta");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_proposta_UsuarioId",
+                table: "proposta",
+                column: "UsuarioId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_proposta_usuario_UsuarioId",
+                table: "proposta",
+                column: "UsuarioId",
+                principalTable: "usuario",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/ETrocas.Database/Migrations/ETrocasDbContextModelSnapshot.cs
+++ b/ETrocas.Database/Migrations/ETrocasDbContextModelSnapshot.cs
@@ -74,7 +74,6 @@ namespace ETrocas.Database.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DataResposta")
-                        .IsRequired()
                         .HasColumnType("datetime2");
 
                     b.Property<string>("Mensagem")
@@ -89,7 +88,7 @@ namespace ETrocas.Database.Migrations
                     b.Property<int>("StatusProposta")
                         .HasColumnType("int");
 
-                    b.Property<Guid?>("UsuarioId")
+                    b.Property<Guid>("UsuarioRecebedorId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("UsuarioPropostaId")
@@ -104,7 +103,7 @@ namespace ETrocas.Database.Migrations
 
                     b.HasIndex("ProdutoOfertadoId");
 
-                    b.HasIndex("UsuarioId");
+                    b.HasIndex("UsuarioRecebedorId");
 
                     b.HasIndex("UsuarioPropostaId");
 
@@ -162,9 +161,11 @@ namespace ETrocas.Database.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("ETrocas.Domain.Entities.Usuario", null)
+                    b.HasOne("ETrocas.Domain.Entities.Usuario", "UsuarioRecebedor")
                         .WithMany("PropostasRecebidas")
-                        .HasForeignKey("UsuarioId");
+                        .HasForeignKey("UsuarioRecebedorId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
 
                     b.HasOne("ETrocas.Domain.Entities.Usuario", "UsuarioProposta")
                         .WithMany("PropostasFeitas")
@@ -177,6 +178,8 @@ namespace ETrocas.Database.Migrations
                     b.Navigation("ProdutoOfertado");
 
                     b.Navigation("UsuarioProposta");
+
+                    b.Navigation("UsuarioRecebedor");
                 });
 
             modelBuilder.Entity("ETrocas.Domain.Entities.Usuario", b =>

--- a/ETrocas.Database/Repository/PropostaRepository.cs
+++ b/ETrocas.Database/Repository/PropostaRepository.cs
@@ -1,11 +1,12 @@
 ﻿using ETrocas.Domain.Entities;
+using ETrocas.Domain.Enums;
 using ETrocas.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace ETrocas.Database.Repository
 {
     public class PropostaRepository : IPropostaRepository
     {
-        //injeção de deprendencia.
         private readonly ETrocasDbContext _eTrocasDbContext;
 
         public PropostaRepository(ETrocasDbContext eTrocasDbContext)
@@ -13,11 +14,40 @@ namespace ETrocas.Database.Repository
             _eTrocasDbContext = eTrocasDbContext;
         }
 
-        //logica de manipulação no banco de dados.
         public async Task<Proposta> FazerPropostaAsync(Proposta proposta)
         {
-            //adiciono essa proposta no b.d e salvo ela.
-            await _eTrocasDbContext.AddAsync(proposta);
+            await _eTrocasDbContext.Propostas.AddAsync(proposta);
+            await _eTrocasDbContext.SaveChangesAsync();
+            return proposta;
+        }
+
+        public async Task<Proposta?> GetByIdAsync(Guid propostaId)
+        {
+            return await _eTrocasDbContext.Propostas
+                .FirstOrDefaultAsync(p => p.Id == propostaId);
+        }
+
+        public async Task<IReadOnlyCollection<Proposta>> ListarEnviadasAsync(Guid usuarioId)
+        {
+            return await _eTrocasDbContext.Propostas
+                .Where(p => p.UsuarioPropostaId == usuarioId)
+                .OrderByDescending(p => p.DataProposta)
+                .ToListAsync();
+        }
+
+        public async Task<IReadOnlyCollection<Proposta>> ListarRecebidasAsync(Guid usuarioId)
+        {
+            return await _eTrocasDbContext.Propostas
+                .Where(p => p.UsuarioRecebedorId == usuarioId)
+                .OrderByDescending(p => p.DataProposta)
+                .ToListAsync();
+        }
+
+        public async Task<Proposta> AtualizarStatusAsync(Proposta proposta, EStatusProposta status)
+        {
+            proposta.StatusProposta = status;
+            proposta.DataResposta = DateTime.UtcNow;
+            _eTrocasDbContext.Propostas.Update(proposta);
             await _eTrocasDbContext.SaveChangesAsync();
             return proposta;
         }

--- a/ETrocas.Domain/Entities/Proposta.cs
+++ b/ETrocas.Domain/Entities/Proposta.cs
@@ -7,13 +7,16 @@ public class Proposta : IEntity
 {
     public Guid Id { get; set; }
     public required DateTime DataProposta { get; set; } = DateTime.Now;
-    public required DateTime DataResposta {  get; set; }
+    public DateTime? DataResposta { get; set; }
     public EStatusProposta StatusProposta { get; set; } = EStatusProposta.Pendente;
     public decimal ValorProposto { get; set; }
     public string? Mensagem { get; set; }
 
     public Guid UsuarioPropostaId { get; set; }
     public Usuario? UsuarioProposta { get; set; }
+
+    public Guid UsuarioRecebedorId { get; set; }
+    public Usuario? UsuarioRecebedor { get; set; }
 
     public Guid ProdutoDesejadoId { get; set; }
     public Produtos? ProdutoDesejado { get; set; }

--- a/ETrocas.Domain/Interfaces/IPropostaRepository.cs
+++ b/ETrocas.Domain/Interfaces/IPropostaRepository.cs
@@ -1,8 +1,13 @@
 ﻿using ETrocas.Domain.Entities;
+using ETrocas.Domain.Enums;
 
 namespace ETrocas.Domain.Interfaces;
 
 public interface IPropostaRepository
 {
-    Task<Proposta> FazerPropostaAsync (Proposta proposta);
+    Task<Proposta> FazerPropostaAsync(Proposta proposta);
+    Task<Proposta?> GetByIdAsync(Guid propostaId);
+    Task<IReadOnlyCollection<Proposta>> ListarEnviadasAsync(Guid usuarioId);
+    Task<IReadOnlyCollection<Proposta>> ListarRecebidasAsync(Guid usuarioId);
+    Task<Proposta> AtualizarStatusAsync(Proposta proposta, EStatusProposta status);
 }

--- a/Etrocas.Application/Interfaces/IPropostaService.cs
+++ b/Etrocas.Application/Interfaces/IPropostaService.cs
@@ -1,9 +1,13 @@
 ﻿using ETrocas.Application.Requests;
 using ETrocas.Application.Responses;
+using ETrocas.Domain.Enums;
 
 namespace ETrocas.Application.Interfaces;
 
 public interface IPropostaService
 {
-    Task<PropostaResponse> FazerPropostaAsync(PropostaRequest request);
+    Task<PropostaResponse> FazerPropostaAsync(PropostaRequest request, Guid usuarioId);
+    Task<IReadOnlyCollection<PropostaResponse>> ListarEnviadasAsync(Guid usuarioId);
+    Task<IReadOnlyCollection<PropostaResponse>> ListarRecebidasAsync(Guid usuarioId);
+    Task<PropostaResponse> AtualizarStatusAsync(Guid propostaId, Guid usuarioId, EStatusProposta status);
 }

--- a/Etrocas.Application/Requests/AtualizarStatusPropostaRequest.cs
+++ b/Etrocas.Application/Requests/AtualizarStatusPropostaRequest.cs
@@ -1,0 +1,8 @@
+﻿using ETrocas.Domain.Enums;
+
+namespace ETrocas.Application.Requests;
+
+public class AtualizarStatusPropostaRequest
+{
+    public EStatusProposta Status { get; set; }
+}

--- a/Etrocas.Application/Responses/PropostaResponse.cs
+++ b/Etrocas.Application/Responses/PropostaResponse.cs
@@ -3,12 +3,18 @@
 namespace ETrocas.Application.Responses;
 
 /// <summary>
-/// Retorno de proposta criada.
+/// Retorno de proposta.
 /// </summary>
 public class PropostaResponse
 {
     public Guid Id { get; set; }
     public EStatusProposta Status { get; set; }
     public DateTime DataProposta { get; set; }
+    public DateTime? DataResposta { get; set; }
+    public Guid UsuarioPropostaId { get; set; }
+    public Guid UsuarioRecebedorId { get; set; }
+    public Guid ProdutoDesejadoId { get; set; }
+    public Guid ProdutoOfertadoId { get; set; }
+    public decimal ValorProposto { get; set; }
     public string? Mensagem { get; set; }
 }

--- a/Etrocas.Application/Services/v1/PropostaService.cs
+++ b/Etrocas.Application/Services/v1/PropostaService.cs
@@ -24,7 +24,7 @@ namespace ETrocas.Application.Services.v1
             _mapper = mapper;
         }
 
-        public async Task<PropostaResponse> FazerPropostaAsync(PropostaRequest propostaRequest)
+        public async Task<PropostaResponse> FazerPropostaAsync(PropostaRequest propostaRequest, Guid usuarioId)
         {
             if (propostaRequest.ProdutoDesejadoId == propostaRequest.ProdutoOfertadoId)
             {
@@ -37,6 +37,11 @@ namespace ETrocas.Application.Services.v1
             var produtoOfertado = await _produtoRepository.GetByIdAsync(propostaRequest.ProdutoOfertadoId)
                                  ?? throw new InvalidOperationException("Produto ofertado não encontrado.");
 
+            if (produtoOfertado.UsuarioId != usuarioId)
+            {
+                throw new UnauthorizedAccessException("Você só pode ofertar um produto do seu próprio usuário.");
+            }
+
             if (produtoDesejado.UsuarioId == produtoOfertado.UsuarioId)
             {
                 throw new InvalidOperationException("Não é permitido trocar produtos do mesmo usuário.");
@@ -44,10 +49,88 @@ namespace ETrocas.Application.Services.v1
 
             var proposta = _mapper.Map<Proposta>(propostaRequest);
             proposta.StatusProposta = EStatusProposta.Pendente;
+            proposta.UsuarioPropostaId = usuarioId;
+            proposta.UsuarioRecebedorId = produtoDesejado.UsuarioId;
+            proposta.DataResposta = null;
 
             var propostaCriada = await _propostaRepository.FazerPropostaAsync(proposta);
-
             return _mapper.Map<PropostaResponse>(propostaCriada);
+        }
+
+        public async Task<IReadOnlyCollection<PropostaResponse>> ListarEnviadasAsync(Guid usuarioId)
+        {
+            var propostas = await _propostaRepository.ListarEnviadasAsync(usuarioId);
+            return _mapper.Map<IReadOnlyCollection<PropostaResponse>>(propostas);
+        }
+
+        public async Task<IReadOnlyCollection<PropostaResponse>> ListarRecebidasAsync(Guid usuarioId)
+        {
+            var propostas = await _propostaRepository.ListarRecebidasAsync(usuarioId);
+            return _mapper.Map<IReadOnlyCollection<PropostaResponse>>(propostas);
+        }
+
+        public async Task<PropostaResponse> AtualizarStatusAsync(Guid propostaId, Guid usuarioId, EStatusProposta status)
+        {
+            var proposta = await _propostaRepository.GetByIdAsync(propostaId)
+                           ?? throw new KeyNotFoundException("Proposta não encontrada.");
+
+            switch (status)
+            {
+                case EStatusProposta.Aceita:
+                case EStatusProposta.Recusada:
+                    ValidarRespostaRecebedor(proposta, usuarioId);
+                    break;
+                case EStatusProposta.Cancelada:
+                    ValidarCancelamento(proposta, usuarioId);
+                    break;
+                case EStatusProposta.Concluida:
+                    ValidarConclusao(proposta, usuarioId);
+                    break;
+                default:
+                    throw new InvalidOperationException("Transição de status inválida para o fluxo da proposta.");
+            }
+
+            var atualizada = await _propostaRepository.AtualizarStatusAsync(proposta, status);
+            return _mapper.Map<PropostaResponse>(atualizada);
+        }
+
+        private static void ValidarRespostaRecebedor(Proposta proposta, Guid usuarioId)
+        {
+            if (proposta.UsuarioRecebedorId != usuarioId)
+            {
+                throw new UnauthorizedAccessException("Somente o usuário que recebeu a proposta pode atualizar esse status.");
+            }
+
+            if (proposta.StatusProposta != EStatusProposta.Pendente)
+            {
+                throw new InvalidOperationException("Apenas propostas pendentes podem ser respondidas.");
+            }
+        }
+
+        private static void ValidarCancelamento(Proposta proposta, Guid usuarioId)
+        {
+            if (proposta.UsuarioPropostaId != usuarioId)
+            {
+                throw new UnauthorizedAccessException("Somente o usuário que fez a proposta pode cancelá-la.");
+            }
+
+            if (proposta.StatusProposta != EStatusProposta.Pendente)
+            {
+                throw new InvalidOperationException("Apenas propostas pendentes podem ser canceladas.");
+            }
+        }
+
+        private static void ValidarConclusao(Proposta proposta, Guid usuarioId)
+        {
+            if (proposta.UsuarioPropostaId != usuarioId && proposta.UsuarioRecebedorId != usuarioId)
+            {
+                throw new UnauthorizedAccessException("Somente participantes da proposta podem concluí-la.");
+            }
+
+            if (proposta.StatusProposta != EStatusProposta.Aceita)
+            {
+                throw new InvalidOperationException("Somente propostas aceitas podem ser concluídas.");
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -113,9 +113,13 @@ A API estará disponível conforme as URLs definidas em:
 - `PUT /api/v1/Produtos/AtualizarProduto/{id}` (autenticado)
 - `DELETE /api/v1/Produtos/DeletarProduto/{id}` (autenticado)
 
-### Propostas (`PropostaController`)
+### Propostas (`PropostasController`)
 
-- `POST /api/v1/Proposta/FazerProposta/{id}` (autenticado)
+- `POST /api/v1/Propostas/{id}` (autenticado)
+- `GET /api/v1/Propostas/enviadas` (autenticado)
+- `GET /api/v1/Propostas/recebidas` (autenticado)
+- `PUT /api/v1/Propostas/{id}/status` (autenticado)  
+  > Status aceitos no corpo: `Aceita`, `Recusada`, `Cancelada`, `Concluida`.
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,9 @@ A API estará disponível conforme as URLs definidas em:
 - `PUT /api/v1/Produtos/AtualizarProduto/{id}` (autenticado)
 - `DELETE /api/v1/Produtos/DeletarProduto/{id}` (autenticado)
 
-### Propostas (`PropostasController`)
+### Propostas (`PropostaController`)
 
-- `POST /api/v1/Propostas/{id}` (autenticado)
-- `GET /api/v1/Propostas/enviadas` (autenticado)
-- `GET /api/v1/Propostas/recebidas` (autenticado)
-- `PUT /api/v1/Propostas/{id}/status` (autenticado)  
-  > Status aceitos no corpo: `Aceita`, `Recusada`, `Cancelada`, `Concluida`.
+- `POST /api/v1/Proposta/FazerProposta/{id}` (autenticado)
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
### Motivation
- Implement a complete proposal (proposta) workflow including creation, listing (sent/received) and status transitions to support real application scenarios.
- Track both proposal initiator and recipient in the domain model to enable authorization and proper queries.
- Make `DataResposta` optional to represent unanswered proposals and ensure DB schema matches the domain.
- Add API-level protection so only authenticated users can act on proposals and only authorized users can perform certain transitions.

### Description
- Added new endpoints in `PropostasController` to create a proposal (`POST /api/v1/Propostas/{id}`), list sent (`GET /api/v1/Propostas/enviadas`) and received (`GET /api/v1/Propostas/recebidas`) proposals, and update status (`PUT /api/v1/Propostas/{id}/status`), and centralized extraction of the authenticated user id via `TryGetUsuarioId` and `[Authorize]` on the controller.
- Extended domain model `Proposta` with `UsuarioRecebedorId` and made `DataResposta` nullable, and updated EF configurations in `PropostaEntityConfiguration` and `UsuarioEntityConfiguration` to wire up the new relationships and navigations.
- Added a DB migration `PropostaFluxoCompleto` that adds `UsuarioRecebedorId`, backfills values from related products, makes `DataResposta` nullable, and removes the old `UsuarioId` column.
- Expanded repository and service layers with new methods: `ListarEnviadasAsync`, `ListarRecebidasAsync`, `GetByIdAsync`, and `AtualizarStatusAsync`, and updated `FazerPropostaAsync`/service to accept `usuarioId`, enforce ownership checks, set both participant ids, set initial state, and validate allowed status transitions in `PropostaService`.
- Updated interfaces `IPropostaRepository` and `IPropostaService`, added request DTO `AtualizarStatusPropostaRequest`, and extended `PropostaResponse` to include `DataResposta`, participant and product ids and `ValorProposto`.
- Minor formatting/whitespace adjustments and README updated with new endpoints and accepted status values.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bb5aa2a08329ad125649bc884487)